### PR TITLE
Improve auth feedback and disable email verification

### DIFF
--- a/crietto/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/crietto/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,7 +28,8 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended($this->redirectTo());
+        return redirect()->intended($this->redirectTo())
+            ->with('status', 'ログインに成功しました。ようこそ！');
     }
 
     public function destroy(Request $request)

--- a/crietto/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/crietto/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -45,7 +45,8 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect()->intended($this->redirectTo($user));
+        return redirect()->intended($this->redirectTo($user))
+            ->with('status', 'アカウントの作成が完了しました。ようこそ！');
     }
 
     private function redirectTo(User $user): string

--- a/crietto/app/Models/User.php
+++ b/crietto/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -11,7 +10,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Sanctum\HasApiTokens;
 
-class User extends Authenticatable implements MustVerifyEmail
+class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
 

--- a/crietto/resources/views/auth/login.blade.php
+++ b/crietto/resources/views/auth/login.blade.php
@@ -19,7 +19,7 @@
         </label>
         <a class="text-indigo-600 hover:underline" href="{{ route('password.request') }}">パスワードをお忘れですか？</a>
     </div>
-    <button class="w-full bg-indigo-600 text-white py-2 rounded">ログイン</button>
+    <button type="submit" class="w-full bg-indigo-600 hover:bg-indigo-700 focus:bg-indigo-700 active:bg-indigo-800 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 focus:ring-offset-white text-white py-2 rounded transition-colors duration-200">ログイン</button>
 </form>
 <div class="mt-4 text-center text-sm">
     <a class="text-indigo-600 hover:underline" href="{{ route('register') }}">アカウントを作成</a>

--- a/crietto/resources/views/auth/register.blade.php
+++ b/crietto/resources/views/auth/register.blade.php
@@ -27,7 +27,7 @@
             <option value="parent" @selected(old('role') === 'parent')>保護者</option>
         </select>
     </div>
-    <button class="w-full bg-indigo-600 text-white py-2 rounded">登録する</button>
+    <button type="submit" class="w-full bg-indigo-600 hover:bg-indigo-700 focus:bg-indigo-700 active:bg-indigo-800 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 focus:ring-offset-white text-white py-2 rounded transition-colors duration-200">登録する</button>
 </form>
 <div class="mt-4 text-center text-sm">
     <a class="text-indigo-600 hover:underline" href="{{ route('login') }}">すでにアカウントをお持ちですか？</a>

--- a/crietto/resources/views/layouts/guest.blade.php
+++ b/crietto/resources/views/layouts/guest.blade.php
@@ -8,6 +8,22 @@
 </head>
 <body class="bg-gradient-to-br from-indigo-100 via-white to-pink-100 min-h-screen flex items-center justify-center">
     <div class="w-full max-w-md bg-white shadow-lg rounded-xl p-8">
+        @if (session('status'))
+            <div class="mb-6 bg-green-100 border border-green-300 text-green-900 px-4 py-3 rounded">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        @if ($errors->any())
+            <div class="mb-6 bg-red-100 border border-red-300 text-red-900 px-4 py-3 rounded">
+                <ul class="list-disc pl-5 space-y-1">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
         @yield('content')
     </div>
 </body>

--- a/crietto/routes/web.php
+++ b/crietto/routes/web.php
@@ -16,7 +16,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::middleware(['auth', 'verified'])->group(function () {
+Route::middleware(['auth'])->group(function () {
     Route::get('/dashboard', [StudentDashboardController::class, 'index'])
         ->middleware('can:view-student-dashboard')->name('student.dashboard');
 


### PR DESCRIPTION
## Summary
- show session status and validation errors on guest authentication pages
- add visual feedback to authentication buttons and flash success messages after login/registration
- remove the email verification requirement so new accounts can access dashboards immediately

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d754b4ed7483248d327120b366e245